### PR TITLE
fix: don't panic when return is nil

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -8,7 +8,7 @@ import (
 func TestScrape(t *testing.T) {
 
 	// TestSuccessfulConnection
-	exporter, _ := NewExporter("credentials.json", os.Getenv("GCP_PROJECT"))
+	exporter, _ := NewExporter(os.Getenv("GCP_PROJECT"))
 	up, _, _ := exporter.scrape()
 	if up == 0 {
 		t.Errorf("TestSuccessfulConnection: up=%v, expected=1", up)
@@ -16,7 +16,7 @@ func TestScrape(t *testing.T) {
 
 	// TestFailedConnection
 	// Set the project name to "503" since the Google Compute API will append this to the end of the BasePath
-	exporter, _ = NewExporter("credentials.json", "503")
+	exporter, _ = NewExporter("503")
 	exporter.service.BasePath = "https://httpbin.org/status/"
 	up, _, _ = exporter.scrape()
 	if up != 0 {


### PR DESCRIPTION
If the scrape fails, the return is nil for either project or regionList.
We should not try to access project.Quotas or regionList.Items in that
case.

Bonus: Even if the regionList call fails, we can still return the
project level results.

fixes #8