### PR TITLE
Replace up series

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 credentials.json
 docker-compose.yml
 gcp-quota-exporter
+c.out

--- a/Makefile
+++ b/Makefile
@@ -16,17 +16,21 @@ gcp-quota-exporter : main.go
 	@echo "building go binary"
 	@CGO_ENABLED=0 GOOS=linux go build .
 
-test : check-env
+test : check-test-env
 	@if [[ ! -d ${ARTIFACTS} ]]; then \
 		mkdir ${ARTIFACTS}; \
 	fi
 	go test -v -coverprofile=c.out
 	go tool cover -html=c.out -o coverage.html
 	mv coverage.html /tmp/artifacts
+	rm c.out
 .PHONY : test
 
-check-env :
-ifndef GCP_PROJECT
-	$(error GCP_PROJECT is undefined)
+check-test-env :
+ifndef GOOGLE_PROJECT_ID
+	$(error GOOGLE_PROJECT_ID is undefined)
+endif
+ifndef GOOGLE_APPLICATION_CREDENTIALS
+	$(error GOOGLE_APPLICATION_CREDENTIALS is undefined)
 endif
 .PHONY : check-env

--- a/main_test.go
+++ b/main_test.go
@@ -8,18 +8,24 @@ import (
 func TestScrape(t *testing.T) {
 
 	// TestSuccessfulConnection
-	exporter, _ := NewExporter(os.Getenv("GCP_PROJECT"))
-	up, _, _ := exporter.scrape()
-	if up == 0 {
-		t.Errorf("TestSuccessfulConnection: up=%v, expected=1", up)
+	exporter, _ := NewExporter(os.Getenv("GOOGLE_PROJECT_ID"))
+	projectUp, regionsUp := exporter.scrape()
+	if projectUp == nil {
+		t.Errorf("TestSuccessfulConnection: projectUp=0, expected=1")
+	}
+	if regionsUp == nil {
+		t.Errorf("TestSuccessfulConnection: regionsUp=0, expected=1")
 	}
 
 	// TestFailedConnection
 	// Set the project name to "503" since the Google Compute API will append this to the end of the BasePath
 	exporter, _ = NewExporter("503")
-	exporter.service.BasePath = "https://httpbin.org/status/"
-	up, _, _ = exporter.scrape()
-	if up != 0 {
-		t.Errorf("TestFailedConnection: up=%v, expected=0", up)
+	exporter.service.BasePath = "http://httpstat.us/"
+	projectUp, regionsUp = exporter.scrape()
+	if projectUp != nil {
+		t.Errorf("TestFailedConnection: projectUp=1, expected=0")
+	}
+	if regionsUp != nil {
+		t.Errorf("TestFailedConnection: regionsUp=1, expected=0")
 	}
 }


### PR DESCRIPTION
With specific up series for `projects` and `regions` since the `up` series is handled by prometheus itself. 

Instead create a `gcp_quota_project_up` and `gcp_quota_regions_up`.

Address one of the requests in https://github.com/mintel/gcp-quota-exporter/issues/10